### PR TITLE
Update the image to have java 21 in it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   check:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:21.0
     resource_class: large
     environment:
       TERM: dumb # necessary to keep gradle daemon alive
@@ -55,7 +55,7 @@ jobs:
 
   publish:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:21.0
     steps:
       - attach_workspace: { at: /home/circleci }
       - run: git status
@@ -66,7 +66,7 @@ jobs:
 
   trial-publish:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:21.0
     steps:
       - attach_workspace: { at: /home/circleci }
       - run: git status


### PR DESCRIPTION
I want to still build for JDK 11 for people, but some of the newer tooling needs newer JDK