### PR TITLE
#165 Pointed out this javadoc does not show the correct return type

### DIFF
--- a/src/main/java/com/palantir/isofilereader/isofilereader/AbstractInternalFile.java
+++ b/src/main/java/com/palantir/isofilereader/isofilereader/AbstractInternalFile.java
@@ -85,9 +85,9 @@ public abstract class AbstractInternalFile<T> {
     public abstract long getSize();
 
     /**
-     * String of parent file name, used to tell full file name and position.
+     * Get the parent file object.
      *
-     * @return string with specified file separators of full file name
+     * @return parent file object, or null if this is the root
      */
     public abstract T getParent();
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update javadoc with correct return type
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

